### PR TITLE
fix: send user_id in DELETE body to match backend members endpoint

### DIFF
--- a/src/pages/api/groups/[groupId]/members.ts
+++ b/src/pages/api/groups/[groupId]/members.ts
@@ -16,15 +16,19 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
     if (req.method === 'DELETE') {
         const { user_id } = req.query
-        if (!user_id) {
+        if (!user_id || typeof user_id !== 'string') {
             res.status(400).json({ error: 'user_id er påkrevd' })
             return
         }
-        const path = `${process.env.BACKEND_URL}/api/v1/groups/${groupId}/members/${user_id}`
+        const path = `${process.env.BACKEND_URL}/api/v1/groups/${groupId}/members`
         try {
             const backendResponse = await fetch(path, {
                 method: 'DELETE',
-                headers: { Authorization: authorizationHeader },
+                headers: {
+                    Authorization: authorizationHeader,
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify([user_id]),
             })
             if (backendResponse.ok) {
                 res.status(200).json({ success: true })


### PR DESCRIPTION
## Summary
- Next.js-proxyen for `DELETE /api/groups/{groupId}/members` kalte et feil backend-path (`/members/{user_id}`) som ikke finnes. Backend forventer `DELETE /api/v1/groups/{groupId}/members` med `user_ids: List[str]` i body.
- Endringen gjør at sletting av vaktlagsmedlemmer faktisk når backend, slik at fjernede medlemmer ikke dukker opp igjen ved neste `fetchGroups()`.

## Test plan
- [ ] Åpne vaktlag-admin, rediger et vaktlag og fjern et medlem
- [ ] Verifiser at medlemmet forblir fjernet etter reload/`fetchGroups()`
- [ ] Verifiser at DELETE-kallet i nettverksfanen returnerer 200