### PR TITLE
feat: vis no_approver-grunn i diff-forhåndsvisning

### DIFF
--- a/src/components/AvstemmingMangler.tsx
+++ b/src/components/AvstemmingMangler.tsx
@@ -22,6 +22,7 @@ import { useTheme } from '../context/ThemeContext'
 const SKIP_REASON_LABELS: Record<string, string> = {
     too_few_costs: 'Mangler diff (færre enn to kostberegninger)',
     wrong_approve_level: 'Feil status (ikke "Utregning fullført med diff")',
+    no_approver: 'Mangler godkjenning (ingen BDM-/vaktsjef-audit)',
 }
 
 interface DiffPreviewIncluded {


### PR DESCRIPTION
Følger opp backend-fiksen vaktor-plan #187, som legger til en ny skip-grunn `no_approver` (vakt mangler BDM-/vaktsjef-godkjenningsaudit).

## Endring
Legger til lesbar label for `no_approver` i `SKIP_REASON_LABELS`, så grunnen vises pent i «Hoppes over»-tabellen i diff-forhåndsvisningen i stedet for den rå nøkkelen.

## Avhengighet
Krever vaktor-plan #187 for at backend faktisk skal returnere `no_approver`.

## Testing
- `tsc` og `eslint` rene for filen.