### PR TITLE
feat: automatisk varsling til riktig godkjenningsnivå via Slack og e-…

### DIFF
--- a/src/components/VarsleModal.tsx
+++ b/src/components/VarsleModal.tsx
@@ -1,38 +1,75 @@
 import { useState } from 'react'
-import { Alert, Button, Modal, Radio, RadioGroup } from '@navikt/ds-react'
+import { Alert, Button, Modal } from '@navikt/ds-react'
 import { Schedules } from '../types/types'
 import { useTheme } from '../context/ThemeContext'
+
+const ROLE_LABELS: Record<string, string> = {
+    vakthaver: 'Vakthaver',
+    vaktsjef: 'Vaktsjef',
+    leveranseleder: 'Leveranseleder',
+    bdm: 'BDM',
+}
+
+const getTargetRole = (schedule: Schedules): string => {
+    const level = schedule.approve_level
+    if (level === 1) {
+        const isVaktsjef =
+            schedule.user.group_roles?.some(
+                (gr) => gr.group_id === schedule.group_id && gr.role?.title?.toLowerCase() === 'vaktsjef'
+            ) || schedule.user.roles?.some((r) => r.title?.toLowerCase() === 'vaktsjef')
+        return isVaktsjef ? 'leveranseleder' : 'vaktsjef'
+    }
+    if (level === 3) return 'bdm'
+    return 'vakthaver'
+}
+
+const groupByRole = (vakter: Schedules[]): Record<string, Schedules[]> =>
+    vakter.reduce<Record<string, Schedules[]>>((acc, s) => {
+        const role = getTargetRole(s)
+        if (!acc[role]) acc[role] = []
+        acc[role].push(s)
+        return acc
+    }, {})
 
 const VarsleModal = (props: { listeAvVakter: Schedules[]; handleClose: Function; month: Date }) => {
     const { theme } = useTheme()
     const isDarkMode = theme === 'dark'
 
-    const [selectedHowRadio, setSelectedHowRadio] = useState('slack')
-    const [selectedRoleRadio, setSelectedRoleRadio] = useState('vakthaver')
     const [isSubmitting, setIsSubmitting] = useState(false)
     const [result, setResult] = useState<{ ok: boolean; message: string } | null>(null)
 
     const selectedMonth = props.month.toLocaleString('nb-NO', { month: 'long' })
+    const grouped = groupByRole(props.listeAvVakter)
 
     const handleSendAlert = async () => {
         setIsSubmitting(true)
         setResult(null)
         try {
-            const response = await fetch('/api/send_alert', {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({
-                    type: selectedHowRadio,
-                    month: selectedMonth,
-                    role: selectedRoleRadio,
-                    schedule_ids: props.listeAvVakter.map((s) => s.id),
-                }),
-            })
-            if (response.ok) {
-                setResult({ ok: true, message: `Varsel sendt til ${props.listeAvVakter.length} vakter via ${selectedHowRadio}.` })
+            const calls = Object.entries(grouped).flatMap(([role, schedules]) =>
+                (['slack', 'email'] as const).map((type) =>
+                    fetch('/api/send_alert', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({
+                            type,
+                            month: selectedMonth,
+                            role,
+                            schedule_ids: schedules.map((s) => s.id),
+                        }),
+                    })
+                )
+            )
+
+            const responses = await Promise.all(calls)
+            const anyFailed = responses.some((r) => !r.ok)
+            const allFailed = responses.every((r) => !r.ok)
+
+            if (allFailed) {
+                setResult({ ok: false, message: 'Alle varselforsøk feilet. Prøv igjen.' })
+            } else if (anyFailed) {
+                setResult({ ok: true, message: `Varsel delvis sendt for ${props.listeAvVakter.length} vakter (Slack + e-post). Noen forsøk feilet.` })
             } else {
-                const err = await response.json().catch(() => ({}))
-                setResult({ ok: false, message: err?.detail || `Feil ved sending av varsel (HTTP ${response.status}).` })
+                setResult({ ok: true, message: `Varsel sendt til ${props.listeAvVakter.length} vakter via Slack og e-post.` })
             }
         } catch (e) {
             setResult({ ok: false, message: 'Nettverksfeil – klarte ikke å sende varsel.' })
@@ -43,60 +80,53 @@ const VarsleModal = (props: { listeAvVakter: Schedules[]; handleClose: Function;
 
     return (
         <div className="py-12">
-            <Modal open={true} onClose={() => props.handleClose()} header={{ heading: 'Varsle ledere' }} width={600}>
+            <Modal open={true} onClose={() => props.handleClose()} header={{ heading: 'Send påminnelse' }} width={600}>
                 <Modal.Body>
                     <p>
                         <strong>Måned: </strong> {selectedMonth}
                     </p>
+                    <p style={{ marginTop: '8px', color: isDarkMode ? '#b0b0b0' : '#666' }}>
+                        Varsler sendes via <strong>Slack og e-post</strong> til riktig godkjenningsnivå basert på vaktstatus.
+                    </p>
 
                     {result && (
-                        <Alert variant={result.ok ? 'success' : 'error'} style={{ marginBottom: '1rem' }}>
+                        <Alert variant={result.ok ? 'success' : 'error'} style={{ marginTop: '1rem' }}>
                             {result.message}
                         </Alert>
                     )}
 
                     {!result?.ok && (
-                        <form method="dialog" id="alertForm">
-                            <div>
-                                <RadioGroup legend="Hvem skal varsles?" onChange={(val: string) => setSelectedRoleRadio(val)} size="small">
-                                    <Radio value="vakthaver">Vakthaver</Radio>
-                                    <Radio value="vaktsjef">Vaktsjef</Radio>
-                                    <Radio value="leveranseleder">Leveranseleder</Radio>
-                                    <Radio value="bdm">BDM</Radio>
-                                </RadioGroup>
-
-                                <RadioGroup legend="Hvor skal varslet?" onChange={(val: string) => setSelectedHowRadio(val)} size="small">
-                                    <Radio value="slack">Slack</Radio>
-                                    <Radio value="email">Email</Radio>
-                                </RadioGroup>
-                            </div>
-                            <div style={{ marginTop: '20px' }}>
-                                Vil varsle om {props.listeAvVakter.length} vakter:
-                                <div
-                                    style={{
-                                        padding: '10px',
-                                        marginTop: '10px',
-                                        border: isDarkMode ? '1px solid #444' : '1px solid #ccc',
-                                        borderRadius: '5px',
-                                        backgroundColor: isDarkMode ? '#2a2a2a' : '#f8f9fa',
-                                    }}
-                                >
-                                    {props.listeAvVakter.map((schedule, index) => (
-                                        <div
-                                            key={index}
-                                            style={{
-                                                background: isDarkMode ? '#1a1a1a' : '#f0f0f0',
-                                                margin: '5px 0',
-                                                padding: '5px',
-                                                borderRadius: '5px',
-                                            }}
-                                        >
-                                            {schedule.id} --- {schedule.user.name}
-                                        </div>
-                                    ))}
+                        <div style={{ marginTop: '16px' }}>
+                            {Object.entries(grouped).map(([role, schedules]) => (
+                                <div key={role} style={{ marginBottom: '12px' }}>
+                                    <div style={{ fontWeight: 600, marginBottom: '4px', color: isDarkMode ? '#fff' : '#000' }}>
+                                        Varsles: {ROLE_LABELS[role] ?? role} ({schedules.length} vakter)
+                                    </div>
+                                    <div
+                                        style={{
+                                            padding: '8px',
+                                            border: isDarkMode ? '1px solid #444' : '1px solid #ccc',
+                                            borderRadius: '5px',
+                                            backgroundColor: isDarkMode ? '#2a2a2a' : '#f8f9fa',
+                                        }}
+                                    >
+                                        {schedules.map((schedule, index) => (
+                                            <div
+                                                key={index}
+                                                style={{
+                                                    background: isDarkMode ? '#1a1a1a' : '#f0f0f0',
+                                                    margin: '4px 0',
+                                                    padding: '5px',
+                                                    borderRadius: '5px',
+                                                }}
+                                            >
+                                                {schedule.id} — {schedule.user.name}
+                                            </div>
+                                        ))}
+                                    </div>
                                 </div>
-                            </div>
-                        </form>
+                            ))}
+                        </div>
                     )}
                 </Modal.Body>
                 <Modal.Footer>


### PR DESCRIPTION
…post

- Fjerner manuelle valg for kanal (Slack/e-post) og mottakerrolle
- Beregner målrolle automatisk basert på approve_level:
  * 0 (Trenger godkjenning) → vakthaver
  * 1 (Godkjent av ansatt) → vaktsjef, eller leveranseleder hvis vakthaver er vaktsjef
  * 3 (Godkjent av vaktsjef) → BDM
- Sender alltid begge kanaler (Slack + e-post) parallelt per rollegruppe
- Viser gruppert oppsummering i modal før sending