### PR TITLE
fix: vis Fornavn Etternavn i stedet for ident i forhåndsvisning

### DIFF
--- a/src/components/SchedulePreview.tsx
+++ b/src/components/SchedulePreview.tsx
@@ -37,6 +37,7 @@ interface PreviewData {
 interface SchedulePreviewProps {
     groupId: string
     userIds: string[]
+    users: Record<string, string>
     startTimestamp: number
     endTimestamp: number
     rolloverDay: number
@@ -98,6 +99,7 @@ const WeekBadge = styled.span`
 const SchedulePreview = ({
     groupId,
     userIds,
+    users,
     startTimestamp,
     endTimestamp,
     rolloverDay,
@@ -195,7 +197,7 @@ const SchedulePreview = ({
                                                 <Table.Body>
                                                     {previewData.warning.overlapping_periods.map((period, idx) => (
                                                         <Table.Row key={idx}>
-                                                            <Table.DataCell>{period.user_id}</Table.DataCell>
+                                                            <Table.DataCell>{users[period.user_id] ?? period.user_id}</Table.DataCell>
                                                             <Table.DataCell>{period.start_date}</Table.DataCell>
                                                             <Table.DataCell>{period.end_date}</Table.DataCell>
                                                         </Table.Row>
@@ -225,7 +227,7 @@ const SchedulePreview = ({
                                         {previewData.periods.slice(0, 100).map((period, idx) => (
                                             <Table.Row key={idx}>
                                                 <Table.DataCell>
-                                                    <UserBadge>{period.user_id}</UserBadge>
+                                                    <UserBadge>{users[period.user_id] ?? period.user_id}</UserBadge>
                                                 </Table.DataCell>
                                                 <Table.DataCell>
                                                     <DateText>{period.start_date}</DateText>

--- a/src/components/Vaktperioder.tsx
+++ b/src/components/Vaktperioder.tsx
@@ -796,6 +796,9 @@ const Vaktperioder = () => {
                                             .filter((user: User) => user.group_order_index !== 100)
                                             .sort((a: User, b: User) => a.group_order_index! - b.group_order_index!)
                                             .map((user: User) => user.id)}
+                                        users={Object.fromEntries(
+                                            itemData.map((user: User) => [user.id, user.name])
+                                        )}
                                         startTimestamp={startTimestamp || (selectedDay ? selectedDay.getTime() / 1000 : 0)}
                                         endTimestamp={endTimestamp}
                                         rolloverDay={rolloverDay}


### PR DESCRIPTION
Bruker-kolonnen i forhåndsvisningsmodalen viste brukeridentet (f.eks. S123456) i stedet for fullt navn. Løst ved å sende en id→navn-mapping fra Vaktperioder til SchedulePreview og slå opp navn ved rendering.

Fallback til user_id hvis bruker ikke finnes i mappingen.