### PR TITLE
fix: case-insensitiv navneoppslag i forhåndsvisning

### DIFF
--- a/src/components/SchedulePreview.tsx
+++ b/src/components/SchedulePreview.tsx
@@ -197,7 +197,7 @@ const SchedulePreview = ({
                                                 <Table.Body>
                                                     {previewData.warning.overlapping_periods.map((period, idx) => (
                                                         <Table.Row key={idx}>
-                                                            <Table.DataCell>{users[period.user_id] ?? period.user_id}</Table.DataCell>
+                                                            <Table.DataCell>{users[period.user_id?.toUpperCase()] ?? period.user_id}</Table.DataCell>
                                                             <Table.DataCell>{period.start_date}</Table.DataCell>
                                                             <Table.DataCell>{period.end_date}</Table.DataCell>
                                                         </Table.Row>
@@ -227,7 +227,7 @@ const SchedulePreview = ({
                                         {previewData.periods.slice(0, 100).map((period, idx) => (
                                             <Table.Row key={idx}>
                                                 <Table.DataCell>
-                                                    <UserBadge>{users[period.user_id] ?? period.user_id}</UserBadge>
+                                                    <UserBadge>{users[period.user_id?.toUpperCase()] ?? period.user_id}</UserBadge>
                                                 </Table.DataCell>
                                                 <Table.DataCell>
                                                     <DateText>{period.start_date}</DateText>

--- a/src/components/Vaktperioder.tsx
+++ b/src/components/Vaktperioder.tsx
@@ -797,7 +797,7 @@ const Vaktperioder = () => {
                                             .sort((a: User, b: User) => a.group_order_index! - b.group_order_index!)
                                             .map((user: User) => user.id)}
                                         users={Object.fromEntries(
-                                            itemData.map((user: User) => [user.id, user.name])
+                                            itemData.map((user: User) => [user.id.toUpperCase(), user.name])
                                         )}
                                         startTimestamp={startTimestamp || (selectedDay ? selectedDay.getTime() / 1000 : 0)}
                                         endTimestamp={endTimestamp}


### PR DESCRIPTION
Forhåndsvisningen viste fortsatt ident fordi backend returnerer user_id i UPPERCASE (B148446), mens users-mappingen var nøklet på rå user.id (lowercase) fra members-API-et. Oppslaget bommet og falt tilbake til å vise identet.

Normaliserer nå begge sider til uppercase:
- Vaktperioder: bygger mapping med user.id.toUpperCase() som nøkkel
- SchedulePreview: slår opp med period.user_id.toUpperCase() i begge tabeller